### PR TITLE
Update types for better props and name overriding

### DIFF
--- a/packages/react-pixi-fiber/types/index.ts
+++ b/packages/react-pixi-fiber/types/index.ts
@@ -1,7 +1,30 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+// this does not make sense due to using infer often in this file,
+// in those cases the variables/parameters are not used but the types are.
+/* eslint-disable no-unused-vars */
 import * as PIXI from 'pixi.js'
 import * as React from 'react'
+
+// in most cases the auto-generated names are correct but in some cases they are not
+// for example the class name is `HTMLText` but the component name should be `htmlText`
+export const nameOverrides = {
+	HTMLText: 'htmlText',
+} as const
+
+
 type PixiType = typeof PIXI
+
+type Options =
+	| PIXI.ContainerOptions
+	| PIXI.NineSliceSpriteOptions
+	| PIXI.TilingSpriteOptions
+	| PIXI.SpriteOptions
+	| PIXI.MeshOptions
+	| PIXI.GraphicsOptions
+	| PIXI.TextOptions
+	| PIXI.HTMLTextOptions;
+
 type Overloads<T> = T extends {
 	new (...args: infer A1): infer R1;
 	new (...args: infer A2): infer R2;
@@ -30,8 +53,10 @@ type Overloads<T> = T extends {
 		}
 	? [new (...args: A1) => R1]
 	: any;
+
 type ConstructorWithOneParam<T extends new (...args: any[]) => any> =
 	T extends new (args: infer A) => any ? A : never;
+
 type ConstructorParams<T extends new (...args: any[]) => any> =
 	ConstructorWithOneParam<Overloads<T>[number]>;
 
@@ -81,16 +106,23 @@ type AutoFilteredKeys = {
 		: never;
 }[keyof PixiType];
 
+
+type OptionsType<T> = T extends Options ? T : never
+
+// this computes the correct props for each component with the original name since we need
+// the name to index into PixiType
 type PixiElements = {
 	[K in AutoFilteredKeys]: [
-		Lowercase<K>,
+		K extends keyof typeof nameOverrides ? typeof nameOverrides[K] : Uncapitalize<K>,
 			React.PropsWithChildren<
-				ConstructorParams<PixiType[K]>
-				& { init?: readonly any[] }
+				OptionsType<ConstructorParams<PixiType[K]>>
+				& { init?: ConstructorParams<PixiType[K]> }
 		> & React.PropsWithRef<{ ref?: React.MutableRefObject<InstanceType<PixiType[K]>> }>
 	];
 };
 
+// because the names of the components are not the same as the pixi class names we convert
+// our record of KV pairs a record with the correct keys and values.
 type PixiElementsImpl = {
 	[K in keyof PixiElements as PixiElements[K][0]]: PixiElements[K][1];
 };


### PR DESCRIPTION
add `nameOverrides` to allow optional name remapping for edge cases as well as better props determination